### PR TITLE
Note that this may be useless now

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -225,6 +225,7 @@ body {
     background: var(--sub-color)
 }
 
+/** This might be useless now - VVM **/
 #cover-img {
     max-width: 100%;
     max-height: 100%;


### PR DESCRIPTION
Dropped the id from cover-img (ids are more for single instances, no longer valid for our *list* of books) because the rest of your code is more focused on the class of html-img. So this specific css may be useless now. Just adding a comment for your awareness though.